### PR TITLE
Refactor: Improve SMS Driver Validation Flow

### DIFF
--- a/GEMINI.md
+++ b/GEMINI.md
@@ -60,7 +60,7 @@ final class ClassName
 
 1. Extend `AbstractDriver`
 2. Mark as `final class`
-3. Implement `send(): ResponseData`
+3. Implement `execute(): ResponseData`
 4. Override `validate()` to check driver-specific config
 5. Use `$this->recipients` (array) and `$this->message` (string)
 
@@ -81,10 +81,8 @@ final class NewGatewayDriver extends AbstractDriver
 {
     private string $baseUrl = 'https://api.gateway.com';
 
-    public function send(): ResponseData
+    protected function execute(): ResponseData
     {
-        $this->validate();
-
         $response = Http::baseUrl($this->baseUrl)
             ->withToken($this->config['api_token'])
             ->timeout($this->timeout)
@@ -109,8 +107,6 @@ final class NewGatewayDriver extends AbstractDriver
 
     protected function validate(): void
     {
-        parent::validate();
-
         if (! $this->config['api_token']) {
             throw new BartaException('Please set api_token for NewGateway in config/barta.php.');
         }
@@ -126,7 +122,6 @@ final class NewGatewayDriver extends AbstractDriver
 
 - [ ] Extends `AbstractDriver`
 - [ ] Uses `final class`
-- [ ] Calls `$this->validate()` first in `send()`
 - [ ] Uses `implode(',', $this->recipients)` for bulk support
 - [ ] Uses `$this->timeout`, `$this->retry`, `$this->retryDelay`
 - [ ] Returns `ResponseData` object

--- a/README.md
+++ b/README.md
@@ -249,10 +249,8 @@ use Larament\Barta\Exceptions\BartaException;
 
 class CustomGatewayDriver extends AbstractDriver
 {
-    public function send(): ResponseData
+    protected function execute(): ResponseData
     {
-        $this->validate();
-
         $response = Http::withToken($this->config['api_token'])
             ->post('https://api.customgateway.com/sms', [
                 'to' => implode(',', $this->recipients),

--- a/src/Drivers/AbstractDriver.php
+++ b/src/Drivers/AbstractDriver.php
@@ -36,13 +36,27 @@ abstract class AbstractDriver
     /**
      * Send the message
      */
-    abstract public function send(): ResponseData;
+    abstract protected function execute(): ResponseData;
+
+    /**
+     * Send the message immediately.
+     */
+    final public function send(): ResponseData
+    {
+        $this->ensureRequiredParametersAreSet();
+
+        $this->validate();
+
+        return $this->execute();
+    }
 
     /**
      * Queue the message for later sending.
      */
     final public function queue(?string $queue = null, ?string $connection = null): PendingDispatch
     {
+        $this->ensureRequiredParametersAreSet();
+
         $this->validate();
 
         $job = new SendSmsJob(
@@ -119,10 +133,8 @@ abstract class AbstractDriver
         return $phone;
     }
 
-    /**
-     * Validate the recipient and message
-     */
-    protected function validate(): void
+    // Ensure that required parameters are set before sending
+    private function ensureRequiredParametersAreSet(): void
     {
         if (empty($this->recipients)) {
             throw BartaException::missingRecipient();
@@ -131,5 +143,14 @@ abstract class AbstractDriver
         if (empty($this->message)) {
             throw BartaException::missingMessage();
         }
+    }
+
+    /**
+     * Validate driver-specific configuration.
+     * Override this method in child classes if needed.
+     */
+    protected function validate(): void
+    {
+        // Optional: Child classes can override for custom validation
     }
 }

--- a/src/Drivers/AdnsmsDriver.php
+++ b/src/Drivers/AdnsmsDriver.php
@@ -12,10 +12,8 @@ final class AdnsmsDriver extends AbstractDriver
 {
     private string $baseUrl = 'https://portal.adnsms.com/api/v1/secure';
 
-    public function send(): ResponseData
+    protected function execute(): ResponseData
     {
-        $this->validate();
-
         $response = Http::baseUrl($this->baseUrl)
             ->timeout($this->timeout)
             ->retry($this->retry, $this->retryDelay, throw: false)
@@ -44,8 +42,6 @@ final class AdnsmsDriver extends AbstractDriver
 
     protected function validate(): void
     {
-        parent::validate();
-
         if (empty($this->config['api_key'])) {
             throw new BartaException('Please set api_key for ADN in config/barta.php.');
         }

--- a/src/Drivers/AlphasmsDriver.php
+++ b/src/Drivers/AlphasmsDriver.php
@@ -12,10 +12,8 @@ final class AlphasmsDriver extends AbstractDriver
 {
     private string $baseUrl = 'https://api.sms.net.bd';
 
-    public function send(): ResponseData
+    protected function execute(): ResponseData
     {
-        $this->validate();
-
         $params = [
             'api_key' => $this->config['api_key'],
             'msg' => $this->message,
@@ -49,8 +47,6 @@ final class AlphasmsDriver extends AbstractDriver
 
     protected function validate(): void
     {
-        parent::validate();
-
         if (empty($this->config['api_key'])) {
             throw new BartaException('Please set api_key for Alpha in config/barta.php.');
         }

--- a/src/Drivers/BanglalinkDriver.php
+++ b/src/Drivers/BanglalinkDriver.php
@@ -12,10 +12,8 @@ final class BanglalinkDriver extends AbstractDriver
 {
     private string $baseUrl = 'https://vas.banglalink.net/sendSMS';
 
-    public function send(): ResponseData
+    protected function execute(): ResponseData
     {
-        $this->validate();
-
         $response = Http::baseUrl($this->baseUrl)
             ->timeout($this->timeout)
             ->retry($this->retry, $this->retryDelay)
@@ -43,8 +41,6 @@ final class BanglalinkDriver extends AbstractDriver
 
     protected function validate(): void
     {
-        parent::validate();
-
         if (empty($this->config['user_id'])) {
             throw new BartaException('Please set user_id for Banglalink in config/barta.php.');
         }

--- a/src/Drivers/BulksmsDriver.php
+++ b/src/Drivers/BulksmsDriver.php
@@ -12,10 +12,8 @@ final class BulksmsDriver extends AbstractDriver
 {
     private string $baseUrl = 'https://bulksmsbd.net/api';
 
-    public function send(): ResponseData
+    protected function execute(): ResponseData
     {
-        $this->validate();
-
         $response = Http::baseUrl($this->baseUrl)
             ->timeout($this->timeout)
             ->retry($this->retry, $this->retryDelay)
@@ -37,8 +35,6 @@ final class BulksmsDriver extends AbstractDriver
 
     protected function validate(): void
     {
-        parent::validate();
-
         if (empty($this->config['api_key'])) {
             throw new BartaException('Please set api_key for BulkSMS in config/barta.php.');
         }

--- a/src/Drivers/ElitbuzzDriver.php
+++ b/src/Drivers/ElitbuzzDriver.php
@@ -10,10 +10,8 @@ use Larament\Barta\Exceptions\BartaException;
 
 final class ElitbuzzDriver extends AbstractDriver
 {
-    public function send(): ResponseData
+    protected function execute(): ResponseData
     {
-        $this->validate();
-
         $response = Http::timeout($this->timeout)
             ->retry($this->retry, $this->retryDelay)
             ->asForm()
@@ -39,8 +37,6 @@ final class ElitbuzzDriver extends AbstractDriver
 
     protected function validate(): void
     {
-        parent::validate();
-
         if (empty($this->config['url'])) {
             throw new BartaException('Please set url for ElitBuzz in config/barta.php.');
         }

--- a/src/Drivers/EsmsDriver.php
+++ b/src/Drivers/EsmsDriver.php
@@ -12,10 +12,8 @@ final class EsmsDriver extends AbstractDriver
 {
     private string $baseUrl = 'https://login.esms.com.bd/api/v3';
 
-    public function send(): ResponseData
+    protected function execute(): ResponseData
     {
-        $this->validate();
-
         $response = Http::baseUrl($this->baseUrl)
             ->withToken($this->config['api_token'])
             ->timeout($this->timeout)
@@ -41,8 +39,6 @@ final class EsmsDriver extends AbstractDriver
 
     protected function validate(): void
     {
-        parent::validate();
-
         if (! $this->config['sender_id']) {
             throw new BartaException('Please set sender_id for ESMS in config/barta.php.');
         }

--- a/src/Drivers/GrameenphoneDriver.php
+++ b/src/Drivers/GrameenphoneDriver.php
@@ -12,10 +12,8 @@ final class GrameenphoneDriver extends AbstractDriver
 {
     private string $baseUrl = 'https://gpcmp.grameenphone.com/ecmapigw/webresources/ecmapigw.v2';
 
-    public function send(): ResponseData
+    protected function execute(): ResponseData
     {
-        $this->validate();
-
         $response = Http::baseUrl($this->baseUrl)
             ->timeout($this->timeout)
             ->retry($this->retry, $this->retryDelay)
@@ -48,8 +46,6 @@ final class GrameenphoneDriver extends AbstractDriver
 
     protected function validate(): void
     {
-        parent::validate();
-
         if (empty($this->config['username'])) {
             throw new BartaException('Please set username for Grameenphone in config/barta.php.');
         }

--- a/src/Drivers/GreenwebDriver.php
+++ b/src/Drivers/GreenwebDriver.php
@@ -12,10 +12,8 @@ final class GreenwebDriver extends AbstractDriver
 {
     private string $baseUrl = 'https://api.greenweb.com.bd';
 
-    public function send(): ResponseData
+    protected function execute(): ResponseData
     {
-        $this->validate();
-
         $response = Http::baseUrl($this->baseUrl)
             ->timeout($this->timeout)
             ->retry($this->retry, $this->retryDelay)
@@ -40,8 +38,6 @@ final class GreenwebDriver extends AbstractDriver
 
     protected function validate(): void
     {
-        parent::validate();
-
         if (empty($this->config['token'])) {
             throw new BartaException('Please set token for GreenWeb in config/barta.php.');
         }

--- a/src/Drivers/InfobipDriver.php
+++ b/src/Drivers/InfobipDriver.php
@@ -10,10 +10,8 @@ use Larament\Barta\Exceptions\BartaException;
 
 final class InfobipDriver extends AbstractDriver
 {
-    public function send(): ResponseData
+    protected function execute(): ResponseData
     {
-        $this->validate();
-
         $response = Http::baseUrl($this->config['base_url'])
             ->timeout($this->timeout)
             ->retry($this->retry, $this->retryDelay)
@@ -51,8 +49,6 @@ final class InfobipDriver extends AbstractDriver
 
     protected function validate(): void
     {
-        parent::validate();
-
         if (empty($this->config['base_url'])) {
             throw new BartaException('Please set base_url for Infobip in config/barta.php.');
         }

--- a/src/Drivers/LogDriver.php
+++ b/src/Drivers/LogDriver.php
@@ -9,10 +9,8 @@ use Larament\Barta\Data\ResponseData;
 
 class LogDriver extends AbstractDriver
 {
-    public function send(): ResponseData
+    protected function execute(): ResponseData
     {
-        $this->validate();
-
         Log::info('[BARTA] Message sent', [
             'recipients' => $this->recipients,
             'message' => $this->message,

--- a/src/Drivers/MimsmsDriver.php
+++ b/src/Drivers/MimsmsDriver.php
@@ -12,10 +12,8 @@ final class MimsmsDriver extends AbstractDriver
 {
     private string $baseUrl = 'https://api.mimsms.com/api/SmsSending';
 
-    public function send(): ResponseData
+    protected function execute(): ResponseData
     {
-        $this->validate();
-
         $response = Http::baseUrl($this->baseUrl)
             ->timeout($this->timeout)
             ->retry($this->retry, $this->retryDelay)
@@ -43,8 +41,6 @@ final class MimsmsDriver extends AbstractDriver
 
     protected function validate(): void
     {
-        parent::validate();
-
         if (! $this->config['username']) {
             throw new BartaException('Please set username for Mimsms in config/barta.php.');
         }

--- a/src/Drivers/RobiDriver.php
+++ b/src/Drivers/RobiDriver.php
@@ -12,10 +12,8 @@ final class RobiDriver extends AbstractDriver
 {
     private string $baseUrl = 'https://bmpws.robi.com.bd/ApacheGearWS';
 
-    public function send(): ResponseData
+    protected function execute(): ResponseData
     {
-        $this->validate();
-
         $response = Http::baseUrl($this->baseUrl)
             ->timeout($this->timeout)
             ->retry($this->retry, $this->retryDelay)
@@ -41,8 +39,6 @@ final class RobiDriver extends AbstractDriver
 
     protected function validate(): void
     {
-        parent::validate();
-
         if (empty($this->config['username'])) {
             throw new BartaException('Please set username for Robi in config/barta.php.');
         }

--- a/src/Drivers/SmsnocDriver.php
+++ b/src/Drivers/SmsnocDriver.php
@@ -12,10 +12,8 @@ final class SmsnocDriver extends AbstractDriver
 {
     private string $baseUrl = 'https://app.smsnoc.com/api/v3';
 
-    public function send(): ResponseData
+    protected function execute(): ResponseData
     {
-        $this->validate();
-
         $response = Http::baseUrl($this->baseUrl)
             ->withToken($this->config['api_token'])
             ->timeout($this->timeout)
@@ -41,8 +39,6 @@ final class SmsnocDriver extends AbstractDriver
 
     protected function validate(): void
     {
-        parent::validate();
-
         if (! $this->config['api_token']) {
             throw new BartaException('Please set api_token for smsnoc in config/barta.php.');
         }

--- a/src/Drivers/SslDriver.php
+++ b/src/Drivers/SslDriver.php
@@ -12,10 +12,8 @@ final class SslDriver extends AbstractDriver
 {
     private string $baseUrl = 'https://smsplus.sslwireless.com/api/v3';
 
-    public function send(): ResponseData
+    protected function execute(): ResponseData
     {
-        $this->validate();
-
         $endpoint = count($this->recipients) > 1 ? '/send-sms/bulk' : '/send-sms';
 
         $response = Http::baseUrl($this->baseUrl)
@@ -44,8 +42,6 @@ final class SslDriver extends AbstractDriver
 
     protected function validate(): void
     {
-        parent::validate();
-
         if (empty($this->config['api_token'])) {
             throw new BartaException('Please set api_token for SSL Wireless in config/barta.php.');
         }

--- a/tests/Drivers/AbstractDriverTest.php
+++ b/tests/Drivers/AbstractDriverTest.php
@@ -8,10 +8,9 @@ use Larament\Barta\Exceptions\BartaException;
 
 class ConcreteDriver extends AbstractDriver
 {
-    public function send(): ResponseData
+    protected function execute(): ResponseData
     {
         // Concrete implementation for testing abstract methods
-        $this->validate();
 
         return new ResponseData(success: true);
     }


### PR DESCRIPTION
## Refactor: Improve SMS Driver Validation Flow

### Changes

**Abstract Driver (`AbstractDriver`)**
- Changed `send()` from abstract to final method
- Added new abstract method `execute()` for child implementations
- Made `validate()` optional - empty by default, override when needed
- Validation now automatically runs before every send/queue operation

**Concrete Drivers (e.g., `AdnsmsDriver`)**
- Renamed `send()` → `execute()` 
- Removed validation call from implementation
- Focused solely on HTTP request logic
- `validate()` still overridden for driver-specific config checks

### Benefits

**Separation of Concerns**: Child classes only handle API integration  
**Consistent Validation**: Automatic validation before every send/queue operation  
**Cleaner Code**: No repetitive validation in child classes  
**Flexible**: `validate()` is optional - use only when needed  

### Before
```php
public function send(): ResponseData
{
    $this->validate(); // Must remember to call this
    
    // HTTP logic here
}
```

### After
```php
protected function execute(): ResponseData
{
    // Only HTTP logic - validation is automatic
}
```

### Testing
- [x] Existing tests pass
- [x] Validation still throws exceptions for missing recipients/message
- [x] Driver-specific validation still works (API keys, etc.)